### PR TITLE
support ast.MapType in typeString

### DIFF
--- a/astop.go
+++ b/astop.go
@@ -54,6 +54,8 @@ func typeString(x ast.Expr) string {
 		return "..." + typeString(typ.Elt)
 	case *ast.ArrayType:
 		return "[]" + typeString(typ.Elt)
+	case *ast.MapType:
+		return "map[" + typeString(typ.Key) + "]" + typeString(typ.Value)
 	default:
 		warnf("typeString doesn't support: %T", typ)
 	}


### PR DESCRIPTION
Using koron/mockgo, I found an error "typeString doesn't support: map".